### PR TITLE
Migrate from Laravel Mix to Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,41 +1,43 @@
 {
-	"private": true,
-	"type": "module",
-	"scripts": {
-		"dev": "npm run development",
-		"development": "mix",
-		"watch": "mix watch",
-		"watch-poll": "mix watch -- --watch-options-poll=1000",
-		"hot": "mix watch --hot",
-		"prod": "npm run production",
-		"production": "mix --production"
-	},
-	"dependencies": {
-		"@babel/preset-react": "^7.22.15",
-		"@hookform/resolvers": "^3.3.1",
-		"axios": "^1.5.1",
-		"bootstrap": "^5.3.2",
-		"dotenv": "^16.3.1",
-		"laravel-mix": "^6.0.49",
-		"lodash": "^4.17.21",
-		"react": "^18.2.0",
-		"react-dom": "^18.2.0",
-		"react-hook-form": "^7.46.2",
-		"react-router-dom": "^6.16.0",
-		"sweetalert2": "^11.7.31",
-		"yup": "1.2.0"
-	},
-	"devDependencies": {
-		"babel-eslint": "^10.1.0",
-		"eslint": "^8.50.0",
-		"eslint-config-airbnb": "^19.0.4",
-		"eslint-plugin-import": "^2.28.1",
-		"eslint-plugin-jsx-a11y": "^6.7.1",
-		"eslint-plugin-react": "^7.33.2",
-		"eslint-plugin-react-hooks": "^4.6.0",
-		"prettier-eslint": "^15.0.1",
-		"resolve-url-loader": "^5.0.0",
-		"sass": "^1.68.0",
-		"sass-loader": "^12.6.0"
-	}
+    "private": true,
+    "type": "module",
+    "scripts": {
+        "dev": "npm run development",
+        "development": "mix",
+        "watch": "mix watch",
+        "watch-poll": "mix watch -- --watch-options-poll=1000",
+        "hot": "mix watch --hot",
+        "prod": "npm run production",
+        "production": "mix --production"
+    },
+    "dependencies": {
+        "@babel/preset-react": "^7.22.15",
+        "@hookform/resolvers": "^3.3.1",
+        "axios": "^1.5.1",
+        "bootstrap": "^5.3.2",
+        "dotenv": "^16.3.1",
+        "lodash": "^4.17.21",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-hook-form": "^7.46.2",
+        "react-router-dom": "^6.16.0",
+        "sweetalert2": "^11.7.31",
+        "yup": "1.2.0",
+        "@vitejs/plugin-react": "^2.0.0"
+    },
+    "devDependencies": {
+        "babel-eslint": "^10.1.0",
+        "eslint": "^8.50.0",
+        "eslint-config-airbnb": "^19.0.4",
+        "eslint-plugin-import": "^2.28.1",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
+        "eslint-plugin-react": "^7.33.2",
+        "eslint-plugin-react-hooks": "^4.6.0",
+        "prettier-eslint": "^15.0.1",
+        "resolve-url-loader": "^5.0.0",
+        "sass": "^1.68.0",
+        "sass-loader": "^12.6.0",
+        "vite": "^3.0.2",
+        "laravel-vite-plugin": "^0.6.0"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -2,13 +2,8 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "dev": "npm run development",
-        "development": "mix",
-        "watch": "mix watch",
-        "watch-poll": "mix watch -- --watch-options-poll=1000",
-        "hot": "mix watch --hot",
-        "prod": "npm run production",
-        "production": "mix --production"
+        "dev": "vite",
+        "build": "vite build"
     },
     "dependencies": {
         "@babel/preset-react": "^7.22.15",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import laravel from 'laravel-vite-plugin';
+
+export default defineConfig({
+    plugins: [
+        laravel({
+            input: ['resources/css/app.css', 'resources/js/app.js'],
+            refresh: true,
+        }),
+    ],
+});


### PR DESCRIPTION
This pull request includes changes for migrating from Laravel Mix to Vite outlined in [Migration Guide](https://github.com/laravel/vite-plugin/blob/main/UPGRADE.md#migrating-from-laravel-mix-to-vite) and automated by the [Vite Converter](https://laravelshift.com/convert-laravel-mix-to-vite).

**Before merging**, you need to:

- Checkout the `shift-104158` branch
- Run `composer update`
- Run `npm install`
- Review **all** comments for additional changes 
- Thoroughly test your application ([no tests?](https://laravelshift.com/laravel-test-generator), [no CI?](https://laravelshift.com/ci-generator))

Please send your feedback to shift@laravelshift.com or share the good vibes on [Twitter](https://twitter.com/laravelshift).
